### PR TITLE
Fix typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First, create your conda environment:
 conda create -n {your project name} python=3.13 exiftool gdal zbar opencv -c conda-forge
 ```
 
-Then, activate your environemt:
+Then, activate your environment:
 
 ```bash
 conda activate {your project name}

--- a/docs/pre_built_html/_sources/install.md.txt
+++ b/docs/pre_built_html/_sources/install.md.txt
@@ -14,7 +14,7 @@ First, create your conda environment:
 conda create -n {your project name} python=3.13 exiftool gdal zbar opencv -c conda-forge
 ```
 
-Then, activate your environemt:
+Then, activate your environment:
 
 ```bash
 conda activate {your project name}

--- a/docs/pre_built_html/_sources/primary_demo.ipynb.txt
+++ b/docs/pre_built_html/_sources/primary_demo.ipynb.txt
@@ -122,7 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "MicaSense raw images contain metatdata including sensor information, GPS coordianates, and more. We can use the `write_metadata_csv()` function to extract image metadata and save it as .csv. \n",
+    "MicaSense raw images contain metadata including sensor information, GPS coordianates, and more. We can use the `write_metadata_csv()` function to extract image metadata and save it as .csv. \n",
     "\n",
     "Let's open the first five lines of the .csv to take a look."
    ]
@@ -1939,7 +1939,7 @@
    "source": [
     "There are two options for georeferencing: you can either set fixed parameters or allow the function to use values saved in the image metadata.\n",
     "\n",
-    "In this example, the image metadata lists the altitude of ~260-265 m, but the flight was planned for 87 m. We will therfore use a set altitude of 87 m. \n",
+    "In this example, the image metadata lists the altitude of ~260-265 m, but the flight was planned for 87 m. We will therefore use a set altitude of 87 m. \n",
     "\n",
     "For the sensor yaw angle: if it remains consistent throughout the flight, a single fixed value can be used. If the yaw changes between transects, as in this example, you should provide a separate yaw value for each transect. The `georeference()` function can accept a `lines` parameter, which can be created manually or generated automatically using the `compute_flight_lines()` function. This produces a list of capture indices per transect with the median yaw angle, ignoring images collected during turns. More details are available in the Processing and Theory section of the [DroneWQ Read the Docs](https://dronewq.readthedocs.io/en/latest/index.html).\n",
     "\n",

--- a/docs/pre_built_html/_sources/theory.md.txt
+++ b/docs/pre_built_html/_sources/theory.md.txt
@@ -44,7 +44,7 @@ Eq. 6&nbsp;&nbsp;&nbsp;&nbsp; R<sub>rs</sub>(θ, Φ, λ) = R<sub>UAS</sub>(θ, �
 
 `DroneWQ` provides multiple options from the literature for removing L<sub>SR</sub>.
 
-A secondary challenge with aquatic UAS remote sensing is georferencing and mosaicking imagery. Many UAS remote sensing studies use Structure-from-Motion (SfM) photogrammetric techniques to stitch individual UAS images into ortho- and georectified mosaics. Current photogrammetry techniques are not capable of stitching UAS images captured over large bodies of water due to a lack of key points in images of homogenous water surfaces. <br>
+A secondary challenge with aquatic UAS remote sensing is georferencing and mosaicking imagery. Many UAS remote sensing studies use Structure-from-Motion (SfM) photogrammetric techniques to stitch individual UAS images into ortho- and georectified mosaics. Current photogrammetry techniques are not capable of stitching UAS images captured over large bodies of water due to a lack of key points in images of homogeneous water surfaces. <br>
 
 The main processing script has the ability to **1)** convert raw multispectral imagery to total radiance (L<sub>t</sub>) with units of W/m<sup>2</sup>/nm/sr, **2)** remove surface reflected light (L<sub>sr</sub>) to calculate water leaving radiance (L<sub>w</sub>), **3)** measure downwelling irradiance (E<sub>d</sub>) from either the calibrated reflectance panel, downwelling light sensor (DLS), or a combination of the two, **4)** calculate remote sensing reflectance (R<sub>rs</sub>) by dividing E<sub>d</sub> by L<sub>w</sub>, and **5)** mask pixels containing specular sun glint or instances of vegetation, shadowing, etc., **6)** use R<sub>rs</sub> as input into various bio-optical algorithms to derive chlorophyll a and total suspended sediment concentrations, and **7)** georeference using image metadata and sensor specifications to orient and map to a known coordinate system. 
 
@@ -61,7 +61,7 @@ In `DroneWQ`, we provide the following methods to calculate L<sub>w</sub>:
 
 `Blackpixel`
 <br/>
-One method to remove L<sub>SR</sub> relies on the so-called black pixel assumption that assumes L<sub>W</sub> in the near infrared (NIR) is negligible due to strong absorption of water. Where this assumption holds, at-sensor radiance measured in the NIR is solely L<sub>SR</sub> and allows ⍴ to be calculated if L<sub>sky</sub> is known. Studies have used this assumption to estimate and remove L<sub>SR</sub>; however, the assumption tends to fail in more turbid waters where high concentrations of particles enhance backscattering and L<sub>W</sub> in the NIR [(Siegel et al 2000)](https://doi.org/10.1364/AO.39.003582). *Therefore, this method should only be used in waters whose optical propeties are dominated and co-vary with phytoplankton (e.g. Case 1, open ocean waters).* 
+One method to remove L<sub>SR</sub> relies on the so-called black pixel assumption that assumes L<sub>W</sub> in the near infrared (NIR) is negligible due to strong absorption of water. Where this assumption holds, at-sensor radiance measured in the NIR is solely L<sub>SR</sub> and allows ⍴ to be calculated if L<sub>sky</sub> is known. Studies have used this assumption to estimate and remove L<sub>SR</sub>; however, the assumption tends to fail in more turbid waters where high concentrations of particles enhance backscattering and L<sub>W</sub> in the NIR [(Siegel et al 2000)](https://doi.org/10.1364/AO.39.003582). *Therefore, this method should only be used in waters whose optical properties are dominated and co-vary with phytoplankton (e.g. Case 1, open ocean waters).* 
 
 `Mobley_rho`
 <br/>
@@ -123,7 +123,7 @@ This is the OCx algorithm which uses a fourth-order polynomial relationship [(O'
 
 `chl_hu_ocx`
 <br/>
-This is the blended NASA chlorophyll algorithm which merges the Hu et al. (2012) color index (CI) algorithm (chl_hu) and the O'Reilly et al. (1998) band ratio OCx algortihm (chl_ocx). This specific code is grabbed from https://github.com/nasa/HyperInSPACE. Documentation can be found here https://www.earthdata.nasa.gov/apt/documents/chlor-a/v1.0.
+This is the blended NASA chlorophyll algorithm which merges the Hu et al. (2012) color index (CI) algorithm (chl_hu) and the O'Reilly et al. (1998) band ratio OCx algorithm (chl_ocx). This specific code is grabbed from https://github.com/nasa/HyperInSPACE. Documentation can be found here https://www.earthdata.nasa.gov/apt/documents/chlor-a/v1.0.
 <br/>
 
 `chl_gitelson`
@@ -167,7 +167,7 @@ Notes on georeferencing:
     * pitch = 0°, roll = 0°, yaw = 90° means: the sensor is nadir (looking down to the ground), the sensor is assumed to be fixed (or on a gimbal), and not moving side to side, the top of the image points to the east.
 <br/>
 
-* If possible, it is recommended to fly the UAS using a consistent yaw angle (e.g. UAS/sensor does not turn 180° every transect). This will make georeferencing easier and alleviate issues with changing sun glint on different transects. Some UAS flight planning softwares allow you to do this (e.g. [UgCS](https://www.sphengineering.com/flight-planning). If not, it is recommended that you note the UAS/sensor's yaw angle and use this in the `georeference` function.
+* If possible, it is recommended to fly the UAS using a consistent yaw angle (e.g. UAS/sensor does not turn 180° every transect). This will make georeferencing easier and alleviate issues with changing sun glint on different transects. Some UAS flight planning software allow you to do this (e.g. [UgCS](https://www.sphengineering.com/flight-planning). If not, it is recommended that you note the UAS/sensor's yaw angle and use this in the `georeference` function.
 * If a yaw angle is not available, it is recommended to test a couple captures that contain land or the shoreline. The MicaSense sensor contains an Inertial Measurement Unit (IMU) that collects data on the sensor pitch, roll, and yaw; however, this data can be impacted by IMU errors, especially during turns and windy flights. You can see how much the sensor yaw angle varies by plotting the IMU metadata yaw angle over captures. An example is included in the primary_demo.ipynb.
     * If you have a small dataset, you can manually go through the captures to select which ones line up with what transect to inform the yaw angle in the georeference() function. It is recommended to skip images that are taken when the UAS/sensor is turning since the IMU is prone to errors during UAS turns.
     * If you have a large dataset where this can be too time consuming, we have provided functions to automatically select captures with varying yaw angles that line up with different transects. The `compute_flight_lines` function returns a list of image captures taken in different transects that contain consistent yaw angles. This can be incorporated into the  `georeference` function to improve georeferencing and mosaicking.

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -14,7 +14,7 @@ First, create your conda environment:
 conda create -n {your project name} python=3.13 exiftool gdal zbar opencv -c conda-forge
 ```
 
-Then, activate your environemt:
+Then, activate your environment:
 
 ```bash
 conda activate {your project name}

--- a/docs/source/theory.md
+++ b/docs/source/theory.md
@@ -44,7 +44,7 @@ Eq. 6&nbsp;&nbsp;&nbsp;&nbsp; R<sub>rs</sub>(θ, Φ, λ) = R<sub>UAS</sub>(θ, �
 
 `DroneWQ` provides multiple options from the literature for removing L<sub>SR</sub>.
 
-A secondary challenge with aquatic UAS remote sensing is georferencing and mosaicking imagery. Many UAS remote sensing studies use Structure-from-Motion (SfM) photogrammetric techniques to stitch individual UAS images into ortho- and georectified mosaics. Current photogrammetry techniques are not capable of stitching UAS images captured over large bodies of water due to a lack of key points in images of homogenous water surfaces. <br>
+A secondary challenge with aquatic UAS remote sensing is georferencing and mosaicking imagery. Many UAS remote sensing studies use Structure-from-Motion (SfM) photogrammetric techniques to stitch individual UAS images into ortho- and georectified mosaics. Current photogrammetry techniques are not capable of stitching UAS images captured over large bodies of water due to a lack of key points in images of homogeneous water surfaces. <br>
 
 The main processing script has the ability to **1)** convert raw multispectral imagery to total radiance (L<sub>t</sub>) with units of W/m<sup>2</sup>/nm/sr, **2)** remove surface reflected light (L<sub>sr</sub>) to calculate water leaving radiance (L<sub>w</sub>), **3)** measure downwelling irradiance (E<sub>d</sub>) from either the calibrated reflectance panel, downwelling light sensor (DLS), or a combination of the two, **4)** calculate remote sensing reflectance (R<sub>rs</sub>) by dividing E<sub>d</sub> by L<sub>w</sub>, and **5)** mask pixels containing specular sun glint or instances of vegetation, shadowing, etc., **6)** use R<sub>rs</sub> as input into various bio-optical algorithms to derive chlorophyll a and total suspended sediment concentrations, and **7)** georeference using image metadata and sensor specifications to orient and map to a known coordinate system. 
 
@@ -61,7 +61,7 @@ In `DroneWQ`, we provide the following methods to calculate L<sub>w</sub>:
 
 `Blackpixel`
 <br/>
-One method to remove L<sub>SR</sub> relies on the so-called black pixel assumption that assumes L<sub>W</sub> in the near infrared (NIR) is negligible due to strong absorption of water. Where this assumption holds, at-sensor radiance measured in the NIR is solely L<sub>SR</sub> and allows ⍴ to be calculated if L<sub>sky</sub> is known. Studies have used this assumption to estimate and remove L<sub>SR</sub>; however, the assumption tends to fail in more turbid waters where high concentrations of particles enhance backscattering and L<sub>W</sub> in the NIR [(Siegel et al 2000)](https://doi.org/10.1364/AO.39.003582). *Therefore, this method should only be used in waters whose optical propeties are dominated and co-vary with phytoplankton (e.g. Case 1, open ocean waters).* 
+One method to remove L<sub>SR</sub> relies on the so-called black pixel assumption that assumes L<sub>W</sub> in the near infrared (NIR) is negligible due to strong absorption of water. Where this assumption holds, at-sensor radiance measured in the NIR is solely L<sub>SR</sub> and allows ⍴ to be calculated if L<sub>sky</sub> is known. Studies have used this assumption to estimate and remove L<sub>SR</sub>; however, the assumption tends to fail in more turbid waters where high concentrations of particles enhance backscattering and L<sub>W</sub> in the NIR [(Siegel et al 2000)](https://doi.org/10.1364/AO.39.003582). *Therefore, this method should only be used in waters whose optical properties are dominated and co-vary with phytoplankton (e.g. Case 1, open ocean waters).* 
 
 `Mobley_rho`
 <br/>
@@ -123,7 +123,7 @@ This is the OCx algorithm which uses a fourth-order polynomial relationship [(O'
 
 `chl_hu_ocx`
 <br/>
-This is the blended NASA chlorophyll algorithm which merges the Hu et al. (2012) color index (CI) algorithm (chl_hu) and the O'Reilly et al. (1998) band ratio OCx algortihm (chl_ocx). This specific code is grabbed from https://github.com/nasa/HyperInSPACE. Documentation can be found here https://www.earthdata.nasa.gov/apt/documents/chlor-a/v1.0.
+This is the blended NASA chlorophyll algorithm which merges the Hu et al. (2012) color index (CI) algorithm (chl_hu) and the O'Reilly et al. (1998) band ratio OCx algorithm (chl_ocx). This specific code is grabbed from https://github.com/nasa/HyperInSPACE. Documentation can be found here https://www.earthdata.nasa.gov/apt/documents/chlor-a/v1.0.
 <br/>
 
 `chl_gitelson`
@@ -167,7 +167,7 @@ Notes on georeferencing:
     * pitch = 0°, roll = 0°, yaw = 90° means: the sensor is nadir (looking down to the ground), the sensor is assumed to be fixed (or on a gimbal), and not moving side to side, the top of the image points to the east.
 <br/>
 
-* If possible, it is recommended to fly the UAS using a consistent yaw angle (e.g. UAS/sensor does not turn 180° every transect). This will make georeferencing easier and alleviate issues with changing sun glint on different transects. Some UAS flight planning softwares allow you to do this (e.g. [UgCS](https://www.sphengineering.com/flight-planning). If not, it is recommended that you note the UAS/sensor's yaw angle and use this in the `georeference` function.
+* If possible, it is recommended to fly the UAS using a consistent yaw angle (e.g. UAS/sensor does not turn 180° every transect). This will make georeferencing easier and alleviate issues with changing sun glint on different transects. Some UAS flight planning software allow you to do this (e.g. [UgCS](https://www.sphengineering.com/flight-planning). If not, it is recommended that you note the UAS/sensor's yaw angle and use this in the `georeference` function.
 * If a yaw angle is not available, it is recommended to test a couple captures that contain land or the shoreline. The MicaSense sensor contains an Inertial Measurement Unit (IMU) that collects data on the sensor pitch, roll, and yaw; however, this data can be impacted by IMU errors, especially during turns and windy flights. You can see how much the sensor yaw angle varies by plotting the IMU metadata yaw angle over captures. An example is included in the primary_demo.ipynb.
     * If you have a small dataset, you can manually go through the captures to select which ones line up with what transect to inform the yaw angle in the georeference() function. It is recommended to skip images that are taken when the UAS/sensor is turning since the IMU is prone to errors during UAS turns.
     * If you have a large dataset where this can be too time consuming, we have provided functions to automatically select captures with varying yaw angles that line up with different transects. The `compute_flight_lines` function returns a list of image captures taken in different transects that contain consistent yaw angles. This can be incorporated into the  `georeference` function to improve georeferencing and mosaicking.

--- a/md_files/APP_MAINTAINENCE_DOCUMENTATION.md
+++ b/md_files/APP_MAINTAINENCE_DOCUMENTATION.md
@@ -284,7 +284,7 @@ hatch run test:run
 
 ## PyPi Release Process
 ### Github Trusted Publishing
-The PyPi package is already linked to the Github respository, so updating the package should be fairly straightforwards. 
+The PyPi package is already linked to the Github repository, so updating the package should be fairly straightforwards. 
 
 **Step 1**
 Update the version in all files, like pyproject.toml, setup.py, or __init__.py

--- a/md_files/TECHNICAL_DOC_BACKEND.md
+++ b/md_files/TECHNICAL_DOC_BACKEND.md
@@ -103,7 +103,7 @@ This is the exact method I used to build the Dronewq.dmg build.
 
 You have to create the most minimal conda env possible so that the app size
 doesn't blow up. I would usually create a conda env dedicated to building the app
-and then not install anything except the `environement.yml` and the `dronewq` package.
+and then not install anything except the `environment.yml` and the `dronewq` package.
 
 ### 2. Copy that env to the app directory
 


### PR DESCRIPTION
Fixes 15 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, dependency names or proper nouns changed, and left alone anything that was a valid word rather than a misspelling.